### PR TITLE
use lib from github

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 rapier2d = "0.17.2"
-minimp4 = "0.1.0"
+minimp4 =  { git = "https://github.com/darkskygit/minimp4.rs" }
 openh264 = "0.4.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.48"


### PR DESCRIPTION
v0.1.0 (current release on cargo) doesn't build properly The error is obscure and comes from proc_macro.
Using lib direct from github fixes issue